### PR TITLE
Allow special characters in usernames

### DIFF
--- a/src/phabricator.coffee
+++ b/src/phabricator.coffee
@@ -169,7 +169,7 @@ module.exports = (robot) ->
           robot.brain.remove keyUser(phid)
           replyToAnon msg
 
-  robot.respond /pha(bricator)? i('m| am) ([a-z0-9]+)/i, (msg) ->
+  robot.respond /pha(bricator)? i('m| am) ([a-zA-Z0-9._-]+)/i, (msg) ->
     userId = msg.message.user.id
     replyWithPHID(robot, userId, msg.match[3]) (phid) ->
       if phid?


### PR DESCRIPTION
Per username rules in https://github.com/phacility/phabricator/blob/8c3ca2a/src/applications/people/storage/PhabricatorUser.php#L705-L718

Without this patch, if I tell hubot phabricator i am dave.mclain the regex will only match dave and will fail when looking up my user account.
