### PR TITLE
Fix constant variables definition issue

### DIFF
--- a/src/phabricator.coffee
+++ b/src/phabricator.coffee
@@ -15,7 +15,7 @@
 #   hubot my reviews - Alias for `phabricator my reviews`
 #   hubot phabricator whoami - Displays your linked Phabricator username guessed based on email
 #   hubot phabricator i am <username> - Sets your linked Phabricator username
-#   hubot phabricator ping - Pings Phabricator's API  
+#   hubot phabricator ping - Pings Phabricator's API
 #   hubot phabricator update signature - Updates session key and connection in Hubot's brain
 #   phabricator subscribe - Subscribes to important actions (**use only in DM**)
 #   phabricator unsubscribe - Unsubscribes from important actions (**use only in DM**)
@@ -24,10 +24,10 @@ _ = require 'lodash'
 sha1 = require 'sha1'
 
 {
-  HUBOT_PHABRICATOR_HOST: PH_HOST # "http://example.com"
-  HUBOT_PHABRICATOR_USER: PH_USER # "username on phabricator"
-  HUBOT_PHABRICATOR_CERT: PH_CERT # "certificate from [PH_HOST]/settings/panel/conduit/"
-  HUBOT_PHABRICATOR_DEBUG_ROOM: DEBUG_ROOM # room to send debugging information to
+  PH_HOST: HUBOT_PHABRICATOR_HOST # "http://example.com"
+  PH_USER: HUBOT_PHABRICATOR_USER # "username on phabricator"
+  PH_CERT: HUBOT_PHABRICATOR_CERT # "certificate from [PH_HOST]/settings/panel/conduit/"
+  DEBUG_ROOM: HUBOT_PHABRICATOR_DEBUG_ROOM  # room to send debugging information to
 } = process.env
 
 if not DEBUG_ROOM


### PR DESCRIPTION
It seems there is an obvious error here. The way to definition of `PH_HOST`, `PH_USER`, `PH_CERT` and `DEBUG_ROOM` is not correct. If we use `PH_HOST` as a value in the expression, we won't get a usable constant variables named `PH_HOST`. 

And as described in the _Configurations_, env variables like `HUBOT_PHABRICATOR_HOST` should be exported instead of `PH_HOST`.

In fact, this hubot script doesn't work even through `HUBOT_PHABRICATOR_HOST`, `HUBOT_PHABRICATOR_USER` and `HUBOT_PHABRICATOR_CERT` are exported in my launch shell script.
